### PR TITLE
add links to 'uses' section

### DIFF
--- a/karngyan.config.js
+++ b/karngyan.config.js
@@ -48,8 +48,8 @@ export default {
     meta: [
       {title: 'OS', value: 'macOS Catalina'},
       {title: 'Memory', value: '16 GB 2667 MHz DDR4'},
-      {title: 'Keyboard', value: 'Keychron K2 - Gateron Brown Keys'},
-      {title: 'Mouse', value: 'Logitech Silent Pebble'},
+      {title: 'Keyboard', value: 'Keychron K2 - Gateron Brown Keys', link: 'https://keychron.in/product/keychron-k2-v-2/'},
+      {title: 'Mouse', value: 'Logitech Silent Pebble', link: 'https://www.amazon.in/Logitech-Pebble-M350-Wireless-Bluetooth/dp/B07X2L5Z8C'},
       {title: 'Monitor', value: 'LG QHD (2560 x 1440) 27 Inch IPS Display'},
       {title: 'Laptop • Processor • Graphics', value: 'MacBook Pro (16-inch, 2019) • 2.6 GHz 6-Core Intel Core i7 • AMD Radeon Pro 5300M 4 GB + Intel UHD Graphics 630 1536 MB'}
     ]

--- a/pages/uses/index.vue
+++ b/pages/uses/index.vue
@@ -46,7 +46,12 @@
             {{ item.title }}
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-400 sm:mt-0 sm:col-span-2">
-            {{ item.value }}
+            <a v-if="item.link !== undefined" :href="`${item.link}`" target="_blank" rel="noreferrer" class="hover:text-hot-pink">
+              {{ item.value }}
+            </a>
+            <a v-if="item.link === undefined">
+              {{ item.value }}
+            </a>
           </dd>
         </div>
       </dl>

--- a/pages/uses/index.vue
+++ b/pages/uses/index.vue
@@ -49,7 +49,7 @@
             <a v-if="item.link !== undefined" :href="`${item.link}`" target="_blank" rel="noreferrer" class="hover:text-hot-pink">
               {{ item.value }}
             </a>
-            <a v-if="item.link === undefined">
+            <a v-else>
               {{ item.value }}
             </a>
           </dd>


### PR DESCRIPTION
User can now add a `link` along with `title` and `value` under the `uses` section in `karngyan.config.js`.
On clicking the `value`, the visitor will be redirected to the `link`.

Sample:
```
uses: {
    enabled: true,
    meta: [{
            title: "Memory",
            value: "32 GB LPDDR5"
        },
        {
            title: "Mouse",
            value: "Logitech MX Master 3S",
            link: "https://www.amazon.in/Logitech-MX-Master-3S-Chrome-Graphite/dp/B0B11LJ69K/ref=sr_1_2?crid=1NHOVPXV7CN0J&keywords=mx%2Bmaster%2B3s&qid=1669211809&qu=eyJxc2MiOiIyLjM2IiwicXNhIjoiMS44NyIsInFzcCI6IjEuODUifQ%3D%3D&sprefix=mx%2Bmaster%2B3%2Caps%2C261&sr=8-2&th=1"
        },
        {
            title: "E-Reader",
            value: "Kindle (10th Gen)",
            link: "https://www.amazon.in/Kindle-10th-Gen/dp/B07FQ4Q7MB"
        }
    ]
}
```

Demo can be found [here](https://www.madhavkauntia.com/uses).