### PR TITLE
chore: baseline version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # karngyan.com
 
-## 2.0.0
+## 0.1.0
 
 ### Major Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karngyan.com",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Re-baselines the changesets version to 0.1.0 for the first GitHub release (no prior tags exist; 0.x signals the template is still settling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)